### PR TITLE
Hardware Interrupts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 
 .DS_Store
+
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pc-keyboard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6f2d937e3b8d63449b01401e2bae4041bc9dd1129c2e3e0d239407cf6635ac"
+
+[[package]]
 name = "pic8259"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +50,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "lazy_static",
+ "pc-keyboard",
  "pic8259",
  "spin",
  "uart_16550",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,11 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pic8259"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ec21f514e2e16e94649f1d041ca4a7069b512c037ac156360652a775e6229d"
+dependencies = [
+ "x86_64",
+]
+
+[[package]]
 name = "rust_os"
 version = "0.1.0"
 dependencies = [
  "bootloader",
  "lazy_static",
+ "pic8259",
  "spin",
  "uart_16550",
  "volatile 0.2.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ volatile = "0.2.6"
 spin = "0.5.2"
 x86_64 = "0.14.2"
 uart_16550 = "0.2.0"
+pic8259 = "0.10.1"
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ spin = "0.5.2"
 x86_64 = "0.14.2"
 uart_16550 = "0.2.0"
 pic8259 = "0.10.1"
+pc-keyboard = "0.5.0"
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,16 +1,19 @@
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
-use crate::{gdt, println};
+use crate::{gdt, print, println};
 use lazy_static::lazy_static;
+use pic8259::ChainedPics;
+use spin;
 
 lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.breakpoint.set_handler_fn(breaking_handler);
-
         unsafe {
             idt.double_fault.set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
+        idt[InterruptIndex::Timer.as_usize()]
+                .set_handler_fn(timer_interrupt_handler);
 
         idt
     };
@@ -33,6 +36,47 @@ extern "x86-interrupt" fn breaking_handler(stack_frame: InterruptStackFrame) {
 extern "x86-interrupt" fn double_fault_handler(
     stack_frame: InterruptStackFrame, _error_code: u64) -> ! {
     panic!("EXCEPTION DOUBLE FAULT\n{:#?}", stack_frame);
+}
+
+pub const PIC_1_OFFSET: u8 = 32;
+pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
+
+// By wrapping the ChainedPics struct in a Mutex we are able to get safe
+// mutable access (through the lock method).
+// The ChainedPics::new function is unsafe because wrong offsets could cause undefined behavior.
+pub static PICS: spin::Mutex<ChainedPics> =
+    spin::Mutex::new( unsafe { ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET) } );
+
+// The enum is a C-like enum so that we can directly specify the index for each variant.
+// The repr(u8) attribute specifies that each variant is represented as an u8.
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum InterruptIndex {
+    Timer = PIC_1_OFFSET,
+}
+
+impl InterruptIndex {
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    fn as_usize(self) -> usize {
+        usize::from(self.as_u8())
+    }
+}
+
+extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: InterruptStackFrame) {
+    print!(".");
+
+    // The notify_end_of_interrupt figures out whether the primary or secondary PIC
+    // sent the interrupt and then uses the command and data ports to send an EOI signal
+    // to respective controllers. If the secondary PIC sent the interrupt both PICs need
+    // to be notified because the secondary PIC is connected to an input line of the primary PIC.
+    //
+    // We need to be careful to use the correct interrupt vector number, otherwise we could
+    // accidentally delete an important unsent interrupt or cause our system to hang.
+    // This is the reason that the function is unsafe.
+    unsafe { PICS.lock().notify_end_of_interrupt(InterruptIndex::Timer.as_u8()) }
 }
 
 #[test_case]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,4 +95,11 @@ fn panic(info: &PanicInfo) -> ! {
 pub fn init() {
     gdt::init();
     interrupts::init_idt();
+    //  initialize the 8259 PIC. It is unsafe because it can cause undefined
+    // behavior if the PIC is misconfigured.
+    unsafe { interrupts::PICS.lock().initialize() };
+
+    // The interrupts::enable function of the x86_64 crate executes the special
+    // sti instruction (“set interrupts”) to enable external interrupts.
+    x86_64::instructions::interrupts::enable();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,12 +67,25 @@ pub fn test_runner(tests: &[&dyn Testable]) {
     exit_qemu(QemuExitCode::Success);
 }
 
+// Until now we used a simple empty loop statement at the end of our _start and panic functions.
+// This causes the CPU to spin endlessly and thus works as expected. But it is also very
+// inefficient, because the CPU continues to run at full speed even though there’s no work to do.
+//
+// What we really want to do is to halt the CPU until the next interrupt arrives.
+// This allows the CPU to enter a sleep state in which it consumes much less energy.
+// The hlt instruction does exactly that.
+pub fn hlt_loop() -> ! {
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+
 // Panic handler in test mode.
 pub fn test_panic_handler(info: &PanicInfo) -> ! {
     serial_println!("[failed]\n");
     serial_println!("Error: {}", info);
     exit_qemu(QemuExitCode::Failed);
-    loop { }
+    hlt_loop();
 }
 
 /// Entry point for `cargo test`
@@ -81,8 +94,7 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
 pub extern "C" fn _start() -> ! {
     init();
     test_main();
-
-    loop { }
+    hlt_loop();
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 #![reexport_test_harness_main = "test_main"]
 
 use core::panic::PanicInfo;
-use rust_os::println;
+use rust_os::{hlt_loop, println};
 
 // function to handle panic, `!` means a function
 // that does not return control to its caller.
@@ -20,7 +20,7 @@ use rust_os::println;
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     println!("{}", info);
-    loop {}
+    hlt_loop();
 }
 
 #[no_mangle] // don't mangle the name of this function
@@ -37,8 +37,7 @@ pub extern "C" fn _start() -> ! {
         test_main();
 
     println!("It did not crash!");
-
-    loop { }
+    hlt_loop();
 }
 
 #[cfg(test)]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -21,7 +21,11 @@ lazy_static! {
 #[doc(hidden)]
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
-    SERIAL1.lock().write_fmt(args).expect("Printing to serial failed");
+    use x86_64::instructions::interrupts;
+
+    interrupts::without_interrupts(|| {
+        SERIAL1.lock().write_fmt(args).expect("Printing to serial failed");
+    });
 }
 
 /// Prints to the host through the serial interface.


### PR DESCRIPTION
## Description

Enable and handle external interrupts. Using the `8259 PIC` and its primary/secondary layout, the remapping of the interrupt numbers, and the “end of interrupt” signal. 

Implement handlers for the hardware timer and the keyboard and use the `hlt` instruction, which halts the CPU until the next interrupt.