### PR TITLE
Implementing memory using paging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bootloader =  "0.9.18"
+bootloader =  { version = "0.9.18", features = ["map_physical_memory"] }
 volatile = "0.2.6"
 spin = "0.5.2"
 x86_64 = "0.14.2"

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -18,6 +18,7 @@ lazy_static! {
                 .set_handler_fn(timer_interrupt_handler);
         idt[InterruptIndex::Keyboard.as_usize()]
                 .set_handler_fn(keyboard_interrupt_handler);
+        idt.page_fault.set_handler_fn(page_fault_handler);
 
         idt
     };
@@ -115,6 +116,21 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: InterruptStac
         PICS.lock()
             .notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
     }
+}
+
+use x86_64::structures::idt::PageFaultErrorCode;
+use crate::hlt_loop;
+
+extern "x86-interrupt" fn page_fault_handler(
+    stack_frame: InterruptStackFrame,
+    error_code: PageFaultErrorCode) {
+    use x86_64::registers::control::Cr2;
+
+    println!("EXCEPTION: PAGE FAULT");
+    println!("Accessed Address: {:?}", Cr2::read());
+    println!("Error code: {:?}", error_code);
+    println!("Stack frame: {:#?}", stack_frame);
+    hlt_loop();
 }
 
 #[test_case]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,14 @@
 
 use core::panic::PanicInfo;
 
+#[cfg(test)]
+use bootloader::{entry_point, BootInfo};
+
 pub mod vga_buffer;
 pub mod serial;
 pub mod interrupts;
 pub mod gdt;
+pub mod memory;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -88,10 +92,12 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
     hlt_loop();
 }
 
+#[cfg(test)]
+entry_point!(test_kernel_main);
+
 /// Entry point for `cargo test`
 #[cfg(test)]
-#[no_mangle]
-pub extern "C" fn _start() -> ! {
+fn test_kernel_main(_boot_info: &'static BootInfo) -> ! {
     init();
     test_main();
     hlt_loop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,14 @@
 #![reexport_test_harness_main = "test_main"]
 
 use core::panic::PanicInfo;
-use rust_os::{hlt_loop, println};
+use rust_os::{hlt_loop, memory, println};
+use bootloader::{BootInfo, entry_point};
+use x86_64::{
+    structures::{
+        paging::{ Translate, Page },
+    },
+    VirtAddr
+};
 
 // function to handle panic, `!` means a function
 // that does not return control to its caller.
@@ -23,8 +30,9 @@ fn panic(info: &PanicInfo) -> ! {
     hlt_loop();
 }
 
-#[no_mangle] // don't mangle the name of this function
-pub extern "C" fn _start() -> ! {
+entry_point!(kernel_main);
+
+fn kernel_main(boot_info: &'static BootInfo) -> ! {
     // this function is the entry point, since the linker looks for a function
     // named `_start` by default.
     println!("Welcome to LumexOS {}\
@@ -33,8 +41,44 @@ pub extern "C" fn _start() -> ! {
     // initialize the IDT to be used by the CPU.
     rust_os::init();
 
+    let phys_mem_offset = VirtAddr::new(boot_info.physical_memory_offset);
+    let mut mapper = unsafe { memory::init(phys_mem_offset) };
+    let mut frame_allocator = unsafe {
+        memory::BootFrameAllocator::init(&boot_info.memory_map)
+    };
+
+    // map an unused page.
+    let page = Page::containing_address(VirtAddr::new(0));
+    memory::create_example_mapping(page, &mut mapper, &mut frame_allocator);
+
+    // write the string `New!` to the screen through the new mapping.
+    // Then we convert the page to a raw pointer and write a value to offset 400.
+    // We don’t write to the start of the page because the top line of the VGA buffer
+    // is directly shifted off the screen by the next println. We write the value
+    // 0x_f021_f077_f065_f04e, which represents the string “New!” on white background.
+    let page_ptr: *mut u64 = page.start_address().as_mut_ptr();
+    unsafe  { page_ptr.offset(400).write_volatile(0x_f021_f077_f065_f04e) };
+
+    let addresses = [
+        // the identity-mapped vga buffer page
+        0xb8000,
+        // some code page
+        0x201008,
+        // some stack page
+        0x0100_0020_1a10,
+        // virtual address mapped to physical address 0.
+        boot_info.physical_memory_offset
+    ];
+
+    for &address in &addresses {
+        let virt = VirtAddr::new(address);
+        // We need to import the Translate trait in order to use the translate_addr method it provides.
+        let phys = mapper.translate_addr(virt);
+        println!("{:?} -> {:?}", virt, phys);
+    }
+
     #[cfg(test)]
-        test_main();
+    test_main();
 
     println!("It did not crash!");
     hlt_loop();

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,165 @@
+use x86_64::{
+    structures::paging::{
+        PageTable,
+        OffsetPageTable,
+        Page,
+        PhysFrame,
+        Mapper,
+        Size4KiB,
+        FrameAllocator,
+        PageTableFlags as Flags,
+    },
+    VirtAddr,
+    PhysAddr,
+    registers::control::Cr3
+};
+use bootloader::bootinfo::{ MemoryMap, MemoryRegionType };
+
+/// A FrameAllocator that always returns `None`.
+pub struct EmptyFrameAllocator;
+
+unsafe impl FrameAllocator<Size4KiB> for EmptyFrameAllocator  {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        None
+    }
+}
+
+/// A FrameAllocator that returns usable frames from the bootloader's memory map.
+///  A 'static reference to the memory map passed by the bootloader and a next field
+/// that keeps track of number of the next frame that the allocator should return.
+pub struct BootFrameAllocator {
+    memory_map: &'static MemoryMap,
+    next: usize,
+}
+
+impl BootFrameAllocator {
+    /// Create a FrameAllocator from the passed memory map.
+    ///
+    /// This function is unsafe because the caller must guarantee that the passed
+    /// memory map is valid. The main requirement is that all frames that are marked
+    /// as `USABLE` in it are really unused.
+    pub unsafe fn init(memory_map: &'static MemoryMap) -> Self {
+        BootFrameAllocator{
+            memory_map,
+            next: 0,
+        }
+    }
+
+    /// Returns an iterator over the usable frames specified in the memory map.
+    /// The return type of the function uses the impl Trait feature. This way,
+    /// we can specify that we return some type that implements the Iterator
+    /// trait with item type PhysFrame, but don’t need to name the concrete return type.
+    /// This is important here because we can’t name the concrete type since it
+    /// depends on unnamable closure types.
+    fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> {
+        // get the usable regions from the memory map.
+        let regions = self.memory_map.iter();
+        // map each region to its address range,
+        // transform to an iterator of frame start addresses
+        let frame_addresses = regions
+            .filter(|r| r.region_type == MemoryRegionType::Usable)
+            .map(|r| r.range.start_addr()..r.range.end_addr())
+            .flat_map(|r| r.step_by(4096));
+
+        // create `PhysFrame` types from the start addresses
+        frame_addresses.map(|addr| PhysFrame::containing_address(PhysAddr::new(addr)))
+    }
+}
+
+unsafe impl FrameAllocator<Size4KiB> for BootFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        let frame = self.usable_frames().nth(self.next);
+        self.next += 1;
+        frame
+    }
+}
+
+/// Creates an example mapping for the given page to frame `0xb8000`.
+/// Deprecated, Pls don't use it anymore.
+pub fn create_example_mapping(
+    page: Page,
+    mapper: &mut OffsetPageTable,
+    frame_allocator: &mut impl FrameAllocator<Size4KiB>,
+) {
+    let frame = PhysFrame::containing_address(PhysAddr::new(0xb8000));
+    let flags = Flags::PRESENT | Flags::WRITABLE;
+
+    let map_to_result = unsafe {
+        // this is for example purpose, it is not safe.
+        mapper.map_to(page, frame, flags, frame_allocator)
+    };
+    map_to_result.expect("map_to failed").flush();
+}
+
+/// Initialize a new OffsetPageTable.
+///
+/// This function is unsafe because the caller must guarantee that the
+/// complete physical memory is mapped to virtual memory at the passed
+/// `physical_memory_offset`. Also, this function must be only called once
+/// to avoid aliasing `&mut` references (which is undefined behavior).
+/// The function takes the physical_memory_offset as an argument and
+/// returns a new OffsetPageTable instance with a 'static lifetime.
+/// This means that the instance stays valid for the complete runtime of our kernel.
+pub unsafe fn init(physical_memory_offset: VirtAddr) -> OffsetPageTable<'static> {
+    let level_4_table = active_level_4_table(physical_memory_offset);
+    OffsetPageTable::new(level_4_table, physical_memory_offset)
+}
+
+/// Returns a mutable reference to the active level 4 table.
+///
+/// This function is unsafe because the caller must guarantee that the
+/// complete physical memory is mapped to virtual memory at the passed
+/// `physical_memory_offset`. Also, this function must be only called once
+/// to avoid aliasing `&mut` references (which is undefined behavior).
+unsafe fn active_level_4_table(physical_memory_offset: VirtAddr)
+    -> &'static mut PageTable {
+    // read the physical frame of the active level 4 table from the CR3 register.
+    let (level_4_table_frame, _) = Cr3::read();
+
+    let phys = level_4_table_frame.start_address();
+    let virt = physical_memory_offset + phys.as_u64();
+    let page_table_ptr: *mut PageTable = virt.as_mut_ptr();
+
+    // deference the pointer to get the value stored in the memory address,
+    // return a mutable reference to that value.
+    &mut *page_table_ptr
+}
+
+// NB: Leaving this for reference purpose, it's not needed anymore.
+/// Private function that is called by `translate_addr`.
+///
+/// This function is safe to limit the scope of `unsafe` because Rust treats
+/// the whole body of unsafe functions as an unsafe block. This function must
+/// only be reachable through `unsafe fn` from outside of this module.
+fn translate_addr_inner(addr: VirtAddr, physical_mem_offset: VirtAddr) -> Option<PhysAddr> {
+    use x86_64::structures::paging::page_table::FrameError;
+    use x86_64::registers::control::Cr3;
+
+    // read the active level 4 frame from the CR3 register.
+    let (level_4_table_frame, _) = Cr3::read();
+
+    let table_indexes = [
+        addr.p4_index(), addr.p3_index(), addr.p2_index(), addr.p1_index()
+    ];
+
+    let mut frame = level_4_table_frame;
+
+    // traverse the multi-level page table.
+    for &index in &table_indexes {
+        // convert the frame into a page table reference
+        let virt = physical_mem_offset + frame.start_address().as_u64();
+        let table_ptr: *const PageTable = virt.as_ptr();
+        let table = unsafe { &*table_ptr };
+
+        // read the page table entry and update `frame`.
+        let entry = &table[index];
+        frame = match entry.frame() {
+            Ok(frame) => frame,
+            Err(FrameError::FrameNotPresent) => return None,
+            Err(FrameError::HugeFrame) => panic!("huge pages are not supported!"),
+        };
+    }
+
+    // calculate the physical address by adding the page offset.
+    Some(frame.start_address() + u64::from(addr.page_offset()))
+}


### PR DESCRIPTION
## Description

This PR contains the implementation of memory paging of virtual addresses using page tables to frames (physical address),

using this [article](https://os.phil-opp.com/paging-implementation/#translating-addresses) as a guide.